### PR TITLE
Fix backend Makefile shell

### DIFF
--- a/chess_backend/Makefile
+++ b/chess_backend/Makefile
@@ -1,5 +1,8 @@
 .PHONY: start dev install setup test clean format lint type-check check-all
 
+# Use bash for shell commands so that 'source' is available
+SHELL := /bin/bash
+
 # Start the development server
 start:
 	@echo "Starting Chess Backend Server..."


### PR DESCRIPTION
## Summary
- fix issue running the backend Makefile by declaring bash as the shell

## Testing
- `make test` *(fails: env not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_6841ccac80e48333be14cf533c6120de