### PR TITLE
Fix fetch_id f-string formatting

### DIFF
--- a/chess_backend/lichess_api.py
+++ b/chess_backend/lichess_api.py
@@ -27,7 +27,9 @@ class Study:
         url = f"https://lichess.org/api/study/{study_id}.pgn"
         response: requests.Response = requests.get(url)
         if response.status_code != 200:
-            raise Exception("Failed to fetch study. Status code: {response.status_code}")
+            raise Exception(
+                f"Failed to fetch study. Status code: {response.status_code}"
+            )
         return Study(chapters=pgn_utils.pgn_to_pgn_list(response.text))
 
     @staticmethod


### PR DESCRIPTION
## Summary
- fix the exception message in `fetch_id` to be an f-string

## Testing
- `cd chess_backend && make test`

------
https://chatgpt.com/codex/tasks/task_e_6841d60041108333a807811cbac1dffe