### PR TITLE
Switch to logger in backend utils

### DIFF
--- a/chess_backend/chess_utils.py
+++ b/chess_backend/chess_utils.py
@@ -5,7 +5,12 @@ This module provides utility functions for chess analysis.
 import os
 from typing import Optional
 
+from logging_config import setup_logging
+
 import chess.pgn
+
+
+logger = setup_logging(__name__)
 
 
 def get_player_color(recent_game: chess.pgn.Game, player_name: str) -> str:
@@ -19,14 +24,16 @@ def get_player_color(recent_game: chess.pgn.Game, player_name: str) -> str:
     white_player = recent_game.headers["White"]
     black_player = recent_game.headers["Black"]
 
-    print(f"[get_player_color] player_name: '{player_name}' | White: '{white_player}' | Black: '{black_player}'")
+    logger.debug(
+        f"[get_player_color] player_name: '{player_name}' | White: '{white_player}' | Black: '{black_player}'"
+    )
     if player_name.strip().lower() == white_player.strip().lower():
-        print("[get_player_color] Matched as White")
+        logger.debug("[get_player_color] Matched as White")
         return "White"
     if player_name.strip().lower() == black_player.strip().lower():
-        print("[get_player_color] Matched as Black")
+        logger.debug("[get_player_color] Matched as Black")
         return "Black"
-    print(f"[get_player_color] No match for player_name: '{player_name}'")
+    logger.debug(f"[get_player_color] No match for player_name: '{player_name}'")
     # Else:
     raise Exception(f"Could not find match {player_name} to the game!")
 
@@ -45,8 +52,8 @@ def write_pgn(pgn_data: str, filename: str) -> None:
     with open(full_path, "wb") as f:
         f.write(pgn_data.encode())  # Convert string to bytes
 
-    # Print confirmation message
-    print(f"PGN data successfully saved to: {full_path}")
+    # Log confirmation message
+    logger.info(f"PGN data successfully saved to: {full_path}")
 
 
 def read_pgn(pgn_file_path: str) -> Optional[chess.pgn.Game]:

--- a/chess_backend/repertoire_trie.py
+++ b/chess_backend/repertoire_trie.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
+from logging_config import setup_logging
+
 import chess
 import chess.pgn
 
@@ -21,6 +23,9 @@ class TrieNode:
 
     def __repr__(self) -> str:
         return f"TrieNode(ply={self.ply}, san={self.san!r}, children={len(self.children)})"
+
+
+logger = setup_logging(__name__)
 
 
 class RepertoireTrie:
@@ -42,7 +47,9 @@ class RepertoireTrie:
 
             if child_node is None:
                 # Use the 'move_san' variable we just created for the log message.
-                print(f"[Trie] Adding new node: {move_san} (ply {temp_board.ply() + 1}) at UCI {uci}")
+                logger.debug(
+                    f"[Trie] Adding new node: {move_san} (ply {temp_board.ply() + 1}) at UCI {uci}"
+                )
                 child_node = TrieNode(ply=temp_board.ply() + 1, san=move_san)
                 current_node.children[uci] = child_node
 
@@ -52,11 +59,13 @@ class RepertoireTrie:
             current_node = child_node
 
     def add_study_chapter(self, chapter: chess.pgn.Game) -> None:
-        print(f"[Trie] Processing chapter starting from FEN: {chapter.headers.get('FEN', 'startpos')}")
+        logger.info(
+            f"[Trie] Processing chapter starting from FEN: {chapter.headers.get('FEN', 'startpos')}"
+        )
         board = chapter.board()
 
         sequences = list(walk_pgn_variations(chapter))
-        print(f"[Trie] Found {len(sequences)} move sequences in chapter.")
+        logger.info(f"[Trie] Found {len(sequences)} move sequences in chapter.")
 
         for move_sequence in sequences:
             # uci_path = " ".join([m.uci() for m in move_sequence])


### PR DESCRIPTION
## Summary
- use the project logger inside `repertoire_trie` and `chess_utils`
- replace print statements with appropriate log calls

## Testing
- `PYTHONPATH=. pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684f6ad5eadc8333a44a586c7fb12788