### PR TITLE
Remove logging import side effect and document gitignore update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cd chess_backend
 make test      # Run tests
 make format    # Format code
 make lint      # Lint code
+python -m logging_config --update-gitignore  # Update .gitignore with log patterns
 ```
 
 ### Frontend Commands

--- a/chess_backend/logging_config.py
+++ b/chess_backend/logging_config.py
@@ -114,5 +114,17 @@ def update_gitignore() -> None:
             f.write("\n# Log files\nlogs/\n*.log\n")
 
 
-# Update .gitignore when module is imported
-update_gitignore()
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Utility helpers for logging configuration")
+    parser.add_argument(
+        "--update-gitignore",
+        action="store_true",
+        help="Add log file patterns to the project's .gitignore",
+    )
+    args = parser.parse_args()
+
+    if args.update_gitignore:
+        update_gitignore()


### PR DESCRIPTION
## Summary
- stop calling `update_gitignore()` when importing `logging_config`
- expose a CLI flag to trigger the update manually
- document the new command in the backend instructions

## Testing
- `cd chess_backend && make test`

------
https://chatgpt.com/codex/tasks/task_e_684f74186e248333a16d9acdbb2128ee