### PR TITLE
Improve ngrok URL retrieval in start script

### DIFF
--- a/chess_backend/start.sh
+++ b/chess_backend/start.sh
@@ -21,7 +21,15 @@ trap 'echo stopping...; kill $PY_PID $NGROK_PID 2>/dev/null || true' INT TERM
 # ───────────────────────────────────────────────
 echo -n "⏳ waiting for ngrok…"
 until curl -s http://localhost:4040/api/tunnels >/dev/null 2>&1; do sleep 1; done
-URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '.tunnels[0].public_url')
+
+# jq is used to parse the ngrok JSON response. If it isn't installed, fall back
+# to Python so the script works on freshly provisioned systems without extra
+# troubleshooting.
+if command -v jq >/dev/null 2>&1; then
+  URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '.tunnels[0].public_url')
+else
+  URL=$(curl -s http://localhost:4040/api/tunnels | python3 -c 'import sys, json; print(json.load(sys.stdin)["tunnels"][0]["public_url"])')
+fi
 echo -e "\n🔗  PUBLIC URL → $URL"
 
 # ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- handle missing `jq` when retrieving ngrok URL
- fall back to Python JSON parsing

## Testing
- `make check-all`
- `npm run format`
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_684f75b7234883338ea6119b96c5fab5