### PR TITLE
Fix private Lichess study access

### DIFF
--- a/chess_backend/analysis_service.py
+++ b/chess_backend/analysis_service.py
@@ -42,6 +42,7 @@ def perform_game_analysis(
     study_url_black: str,
     max_games: int = 10,
     since: Optional[datetime] = None,
+    access_token: Optional[str] = None,
 ) -> List[Tuple[Optional[DeviationResult], str]]:
     """
     Handles the core logic of fetching games, studies, and finding deviations
@@ -66,7 +67,7 @@ def perform_game_analysis(
                     f"[THROTTLE] Sleeping {LICHESS_THROTTLE_DELAY_SECONDS}s before fetching white study due to feature flag."
                 )
                 time.sleep(LICHESS_THROTTLE_DELAY_SECONDS)
-            white_study = lichess_api.Study.fetch_url(str(study_url_white))
+            white_study = lichess_api.Study.fetch_url(str(study_url_white), access_token)
             white_trie = RepertoireTrie()
             for chapter in white_study.chapters:
                 white_trie.add_study_chapter(chapter)
@@ -81,7 +82,7 @@ def perform_game_analysis(
                     f"[THROTTLE] Sleeping {LICHESS_THROTTLE_DELAY_SECONDS}s before fetching black study due to feature flag."
                 )
                 time.sleep(LICHESS_THROTTLE_DELAY_SECONDS)
-            black_study = lichess_api.Study.fetch_url(str(study_url_black))
+            black_study = lichess_api.Study.fetch_url(str(study_url_black), access_token)
             black_trie = RepertoireTrie()
             for chapter in black_study.chapters:
                 black_trie.add_study_chapter(chapter)

--- a/chess_backend/main.py
+++ b/chess_backend/main.py
@@ -136,7 +136,10 @@ async def get_dummy_games() -> dict[str, List[str]]:
 
 
 @app.post("/api/analyze_games", response_model=AnalysisResponse)
-async def analyze_games_endpoint(request: AnalysisRequest) -> AnalysisResponse:
+async def analyze_games_endpoint(
+    request: AnalysisRequest,
+    current_user: User = Depends(get_current_user),
+) -> AnalysisResponse:
     try:
         logger.info(f"Received analysis request for user: {request.username}, scope: {request.scope}")
 
@@ -152,6 +155,7 @@ async def analyze_games_endpoint(request: AnalysisRequest) -> AnalysisResponse:
             study_url_black=str(request.study_url_black),
             max_games=request.max_games,
             since=since,
+            access_token=current_user.access_token,
         )
 
         # Filter out None results and extract just the DeviationResult objects


### PR DESCRIPTION
## Summary
- allow `lichess_api.Study.fetch_id`/`fetch_url` to send Authorization token
- pass user access token through `perform_game_analysis`
- require auth for the `analyze_games` endpoint so private studies work

## Testing
- `cd chess_backend && make check-all`
- `cd chess_frontend && npm run format && npm run lint && npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68562fa8fd008333a726f81ede6532ca